### PR TITLE
remove location overlay to fix location by network

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -155,7 +155,7 @@ PRODUCT_PACKAGES += \
     gps.msm8937 \
     libgnsspps \
     libcurl \
-	gps.conf
+    gps.conf
 
 # Init
 PRODUCT_PACKAGES += \

--- a/device.mk
+++ b/device.mk
@@ -154,7 +154,8 @@ PRODUCT_BOOT_JARS += \
 PRODUCT_PACKAGES += \
     gps.msm8937 \
     libgnsspps \
-    libcurl
+    libcurl \
+	gps.conf
 
 # Init
 PRODUCT_PACKAGES += \

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -318,12 +318,6 @@
     <!-- Flag indicating if the speed up audio on mt call code should be executed -->
     <bool name="config_speed_up_audio_on_mt_calls">true</bool>
 
-    <!-- Enable overlay for all location components. -->
-    <bool name="config_enableNetworkLocationOverlay" translatable="false">false</bool>
-    <string name="config_networkLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-    <bool name="config_enableFusedLocationOverlay" translatable="false">false</bool>
-    <string name="config_fusedLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-
     <!--  Maximum number of supported users -->
     <integer name="config_multiuserMaximumUsers">4</integer>
 


### PR DESCRIPTION
Removing this will make the phone to use FusedLocation that I now is working for all